### PR TITLE
Update README.md with git clone URL for Eternal

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project uses [CMake](https://cmake.org/), a versatile building system that 
 In order to clone the repository, you need to install Git, which you can get [here](https://git-scm.com/downloads).
 
 Clone the repo **recursively**, using:
-`git clone --recursive https://github.com/Rubberduckycooly/Sonic-CD-11-Decompilation`
+`git clone --recursive https://github.com/megadeglitcher/Sonic-CD-Eternal-Decompilation`
 
 If you've already cloned the repo, run this command inside of the repository:
 ``git submodule update --init --recursive```


### PR DESCRIPTION
This changes the URL in the instructions from the upstream RSDKv3 decomp Github to the Eternal Github. Hopefully to avoid a potential issue for users who want to compile Eternal themselves but if they follow the instructions verbatim they compile the RSDKv3 decomp instead.